### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ In addition to this file, there are other large files in the images folder. Comp
 1. Close MySQL Workbench
 2. Copy the files advpng.exe, patch.bat, zlib.dll to the images folder, I have it in "C: \ Program Files \ MySQL \ MySQL Workbench 8.0 CE \ images"
 3. Run patch.bat
-4. Let's open MySQL Workbench
+4. Let's open MySQL Workbench to see the correctly displayed key icons.
+
+If this still didn't work, copy the images folder to the desktop and run patch.bat as above in "desktop \ images" folder. Then overwrite the images folder in "C: \ Program Files \ MySQL \ MySQL Workbench 8.0 CE \ images" with the "desktop \ images" folder. Open MySQL Workbench to see the icons.
 
 Checked for version 8.0.19 windows
 


### PR DESCRIPTION
Added instructions at line 21 for Windows, if the advpng.exe can't overwrite the .png files at images folder at default location "C: \ Program Files \ MySQL \ MySQL Workbench 8.0 CE \ images" due to the unchangeable Read-only attribute of images folder and its sub-folders.